### PR TITLE
Allow multiple-dirs and outputfile as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Just open an issue saying what's missing ! Feel free to open a PR but we recomme
 ## Where to start ?
 - `composer require uderline/openapi-php-attributes`
 - Describe your API by following this documentation: https://uderline.github.io/openapi-php-attributes/
-- Then, generate the JSON file: `php ./vendor/uderline/openapi-php-attributes/opag /src/files/project /save/the/file`.
+- Then, generate the JSON file: `php ./vendor/uderline/openapi-php-attributes/opag /src/files/project openapi.json`.
 
 A new file called `openapi.json` has been generated !
 

--- a/opag
+++ b/opag
@@ -18,7 +18,18 @@ require $autoload_path;
 
 use Symfony\Component\Finder\Finder;
 
-$files = Finder::create()->files()->name('*.php')->in($argv[1]);
+if ($argc <= 2) {
+    $dirs = [$argv[1] ?? './'];
+    $outputFile = './openapi.json';
+} else if (is_dir($argv[$argc - 1])) {
+    $dirs = array_slice($argv, 1);
+    $outputFile = './openapi.json';
+} else {
+    $dirs = array_slice($argv, 1, -1);
+    $outputFile = $argv[$argc - 1];
+}
+
+$files = Finder::create()->files()->name('*.php')->in($dirs);
 
 foreach ($files as $autoload) {
     include_once $autoload->getPathName();
@@ -28,4 +39,4 @@ $generator = \OpenApiGenerator\Generator::create()->generate();
 
 $schema = stripslashes(json_encode($generator, JSON_PRETTY_PRINT));
 
-file_put_contents('./openapi.json', $schema);
+file_put_contents($outputFile, $schema);


### PR DESCRIPTION
Allow to add more arguments to the command:

```bash
# Set output file
php ./vendor/uderline/openapi-php-attributes/opag app/ public/openapai.json

# Scan multiple folders
php ./vendor/uderline/openapi-php-attributes/opag app/ src/ src2/

# combined
php ./vendor/uderline/openapi-php-attributes/opag app/ src/ src2/ public/openapai.json
```