### PR TITLE
match failes, if method have other attributes, fixed

### DIFF
--- a/src/GeneratorHttp.php
+++ b/src/GeneratorHttp.php
@@ -61,6 +61,7 @@ class GeneratorHttp
                     PropertyItems::class => $pathBuilder->setPropertyItems($instance),
                     MediaProperty::class => $pathBuilder->setMediaProperty($instance),
                     Response::class => $pathBuilder->setResponse($instance),
+                    default => null
                 };
             }
 


### PR DESCRIPTION
As the generator fetch all attributes:
https://github.com/uderline/openapi-php-attributes/blob/bde8b843f56723a306968bb2561495cd39c560e4/src/GeneratorHttp.php#L31

And the match() only match agains your attributes:
https://github.com/uderline/openapi-php-attributes/blob/bde8b843f56723a306968bb2561495cd39c560e4/src/GeneratorHttp.php#L52-L64

The generator throws an UnhandledMatchError if the method have any other attributes.

Fixed by adding a default