### PR TITLE
A request extending the Symfony request object can have a schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,23 @@ class Controller {
         Property(PropertyType::STRING, "prop1", description: "Property description", enum: ["val1", "val2"]),
         Property(PropertyType::INT, "prop2", example: 1),
         Property(PropertyType::BOOLEAN, "prop3"),
+        Property(PropertyType::REF, "prop4", ref: RefSchema::class)
         Response(ref: SchemaName::class, description: "Response description")
     ]
     public function get(#[Parameter("Parameter description")] int $id): JsonResponse {
         // ...
     }
+}
+
+#[
+    Schema,
+    Property(Type::STRING, "Property 1"),
+    Property(Type::INT, "Property 2"),
+]
+class RefSchema
+{
+    public string $property1;
+    public int $property2;
 }
 ```
 
@@ -75,6 +87,9 @@ Will generate
                                     "prop3": {
                                         "type": "boolean",
                                         "description": ""
+                                    },
+                                    "prop4": {
+                                        "$ref": "#/components/schemas/RefSchema"
                                     }
                                 }
                             }

--- a/src/Attributes/Property.php
+++ b/src/Attributes/Property.php
@@ -24,8 +24,13 @@ class Property implements PropertyInterface, JsonSerializable
         private string $description = '',
         private mixed $example = null,
         private ?string $format = null,
-        private ?array $enum = null
+        private ?array $enum = null,
+        private ?string $ref = null
     ) {
+        if ($this->ref) {
+            $ref = explode('\\', $this->ref);
+            $this->ref = end($ref);
+        }
     }
 
     public function setPropertyItems(PropertyItems $propertyItems): void
@@ -53,6 +58,10 @@ class Property implements PropertyInterface, JsonSerializable
             if ($this->propertyItems) {
                 return $this->propertyItems->jsonSerialize();
             }
+        }
+
+        if ($this->type === PropertyType::REF) {
+            return ['$ref' => "#/components/schemas/$this->ref"];
         }
 
         if ($this->type === PropertyType::ID) {

--- a/src/Attributes/Schema.php
+++ b/src/Attributes/Schema.php
@@ -59,7 +59,7 @@ class Schema implements JsonSerializable
             $firstProperty = reset($this->properties);
 
             if ($firstProperty instanceof RefProperty || $firstProperty instanceof MediaProperty) {
-                $schema = $firstProperty;
+                $schema = $firstProperty->jsonSerialize();
             } else {
                 $array = [];
 

--- a/src/ComponentBuilder.php
+++ b/src/ComponentBuilder.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace OpenApiGenerator;
 
-use OpenApiGenerator\Attributes\Property;
+use OpenApiGenerator\Attributes\PropertyInterface;
 use OpenApiGenerator\Attributes\PropertyItems;
 use OpenApiGenerator\Attributes\Schema;
 
 class ComponentBuilder
 {
     private ?Schema $currentSchema = null;
-    private ?Property $currentProperty = null;
+    private ?PropertyInterface $currentProperty = null;
+
+    public function __construct(private $noMedia = true)
+    {
+    }
 
     public function addSchema(Schema $schema, string $className): bool
     {
-        $schema->setNoMedia(true);
-
         if (!$schema->getName()) {
             $explodedNamespace = explode('\\', $className);
             $className = end($explodedNamespace);
@@ -28,7 +30,7 @@ class ComponentBuilder
         return true;
     }
 
-    public function addProperty(Property $property): bool
+    public function addProperty(PropertyInterface $property): bool
     {
         $this->saveProperty();
         $this->currentProperty = $property;
@@ -57,6 +59,7 @@ class ComponentBuilder
     public function getComponent(): ?Schema
     {
         $this->saveProperty();
+        $this->currentSchema->setNoMedia($this->noMedia);
 
         return $this->currentSchema;
     }

--- a/tests/Examples/Dummy/DummyController.php
+++ b/tests/Examples/Dummy/DummyController.php
@@ -27,7 +27,9 @@ class DummyController
         GET("/path", ["Dummy"], "Dummy get path"),
         Property(Type::STRING, "prop1", "Prop 1", "val1"),
         Property(Type::STRING, "prop2", "Prop 2", "val2"),
-        Response
+        Response,
+        Property(Type::STRING, "Response prop 1", "Prop response 1", "1"),
+        Property(Type::INT, "Response prop 2", "Prop response 2", 4)
     ]
     public function get(): void
     {
@@ -76,12 +78,9 @@ class DummyController
 
     #[
         PUT("/path/{id}", ["Dummy"], "Dummy put"),
-        Property(Type::STRING, "prop1"),
-        Property(Type::ID, "prop2"),
-        Property(Type::BOOLEAN, "prop3"),
         Response(204)
     ]
-    public function put(#[IDParam] int $id): void
+    public function put(#[IDParam] int $id, DummyRequest $dummyRequest): void
     {
         //
     }

--- a/tests/Examples/Dummy/DummyRequest.php
+++ b/tests/Examples/Dummy/DummyRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OpenApiGenerator\Tests\Examples\Dummy;
+
+use OpenApiGenerator\Attributes\Property;
+use OpenApiGenerator\Attributes\PropertyItems;
+use OpenApiGenerator\Attributes\Schema;
+use OpenApiGenerator\Type;
+use Symfony\Component\HttpFoundation\Request;
+
+#[
+    Schema,
+    Property(Type::STRING, "Property 1"),
+    Property(Type::INT, "Property 2"),
+    Property(Type::ARRAY, "Property 3"),
+    PropertyItems(Type::STRING)
+]
+class DummyRequest extends Request
+{
+
+}

--- a/tests/Examples/Dummy/DummyRequest.php
+++ b/tests/Examples/Dummy/DummyRequest.php
@@ -13,7 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
     Property(Type::STRING, "Property 1"),
     Property(Type::INT, "Property 2"),
     Property(Type::ARRAY, "Property 3"),
-    PropertyItems(Type::STRING)
+    PropertyItems(Type::STRING),
+    Property(Type::REF, "Property 4", ref: DummyRefComponent::class),
 ]
 class DummyRequest extends Request
 {


### PR DESCRIPTION
The schema is automatically put in the request object path if it's passed as a method argument

Linked to #16