### PR TITLE
Allow multiple responses in paths

### DIFF
--- a/src/Attributes/Response.php
+++ b/src/Attributes/Response.php
@@ -16,7 +16,7 @@ use JsonSerializable;
  * Additionally, a schema type can be added (array or object) and a ref which will return any other property
  * Consider the ref parameter like a shortcut
  */
-#[Attribute]
+#[Attribute(Attribute::TARGET_ALL | Attribute::IS_REPEATABLE)]
 class Response implements JsonSerializable
 {
     private ?Schema $schema = null;

--- a/src/Attributes/Route.php
+++ b/src/Attributes/Route.php
@@ -23,7 +23,7 @@ class Route implements JsonSerializable
     public const PATCH = 'patch';
 
     private array $getParams = [];
-    private ?Response $response = null;
+    private array $response = [];
     private ?RequestBody $requestBody = null;
 
     public function __construct(
@@ -40,9 +40,9 @@ class Route implements JsonSerializable
         $this->getParams[] = $params;
     }
 
-    public function setResponse(Response $response): void
+    public function addResponse(Response $response): void
     {
-        $this->response = $response;
+        $this->response[] = $response;
     }
 
     public function getMethod(): string

--- a/src/Attributes/Route.php
+++ b/src/Attributes/Route.php
@@ -107,7 +107,11 @@ class Route implements JsonSerializable
         }
 
         if ($this->response) {
-            $array[$this->getRoute()][$this->method]['responses'] = $this->response;
+            $responses = array_reduce($this->response, function ($response, $current) {
+                return $response + $current->jsonSerialize();
+            }, []);
+
+            $array[$this->getRoute()][$this->method]['responses'] = $responses;
         }
 
         return $array;

--- a/src/Attributes/Route.php
+++ b/src/Attributes/Route.php
@@ -23,7 +23,7 @@ class Route implements JsonSerializable
     public const PATCH = 'patch';
 
     private array $getParams = [];
-    private array $response = [];
+    private array $responses = [];
     private ?RequestBody $requestBody = null;
 
     public function __construct(
@@ -42,7 +42,7 @@ class Route implements JsonSerializable
 
     public function addResponse(Response $response): void
     {
-        $this->response[] = $response;
+        $this->responses[] = $response;
     }
 
     public function getMethod(): string
@@ -106,8 +106,8 @@ class Route implements JsonSerializable
             $array[$this->getRoute()][$this->method]['requestBody'] = $this->requestBody;
         }
 
-        if ($this->response) {
-            $responses = array_reduce($this->response, function ($response, $current) {
+        if ($this->responses) {
+            $responses = array_reduce($this->responses, function ($response, $current) {
                 return $response + $current->jsonSerialize();
             }, []);
 

--- a/src/PathMethodBuilder.php
+++ b/src/PathMethodBuilder.php
@@ -122,7 +122,7 @@ class PathMethodBuilder
             if ($this->currentSchemaHolder instanceof RequestBody) {
                 $this->currentRoute->setRequestBody($this->currentSchemaHolder);
             } else {
-                $this->currentRoute->setResponse($this->currentSchemaHolder);
+                $this->currentRoute->addResponse($this->currentSchemaHolder);
             }
 
             $this->currentSchemaHolder = null;

--- a/tests/Examples/Controller/ManyResponsesController.php
+++ b/tests/Examples/Controller/ManyResponsesController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenApiGenerator\Tests\Examples\Controller;
+
+use OpenApiGenerator\Attributes\Controller;
+use OpenApiGenerator\Attributes\GET;
+use OpenApiGenerator\Attributes\Response;
+
+#[Controller]
+class ManyResponsesController
+{
+    #[
+        GET("/path", ["Dummy"], "Dummy path"),
+        Response(200),
+        Response(401),
+    ]
+    public function get(): void
+    {
+        //
+    }
+}

--- a/tests/GenerateHttpTest.php
+++ b/tests/GenerateHttpTest.php
@@ -13,6 +13,7 @@ use OpenApiGenerator\Attributes\Response;
 use OpenApiGenerator\Attributes\Route;
 use OpenApiGenerator\Attributes\Schema;
 use OpenApiGenerator\GeneratorHttp;
+use OpenApiGenerator\Tests\Examples\Controller\ManyResponsesController;
 use OpenApiGenerator\Tests\Examples\Controller\SimpleController;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -46,7 +47,27 @@ class GenerateHttpTest extends TestCase
         $expectedRoute->addParam($expectedParameter);
         $expectedRoute->addParam($expectedPathParameter);
         $expectedRoute->setRequestBody($requestBody);
-        $expectedRoute->setResponse(new Response());
+        $expectedRoute->addResponse(new Response());
+
+        self::assertEquals([$expectedRoute], $actual);
+    }
+
+    public function testManyResponses(): void
+    {
+        $dummyReflection = new ReflectionClass(ManyResponsesController::class);
+
+        $generateHttp = new GeneratorHttp();
+        $generateHttp->append($dummyReflection);
+
+        $reflection = new ReflectionClass($generateHttp);
+        $pathsProperty = $reflection->getProperty('paths');
+        $pathsProperty->setAccessible(true);
+        $actual = $pathsProperty->getValue($generateHttp);
+
+        $expectedRoute = new GET('/path', ['Dummy'], 'Dummy path');
+        $expectedRoute->setRequestBody(new RequestBody());
+        $expectedRoute->addResponse(new Response());
+        $expectedRoute->addResponse(new Response(401));
 
         self::assertEquals([$expectedRoute], $actual);
     }


### PR DESCRIPTION
The [OAS](https://swagger.io/specification/) allows multiple responses in `paths` to map errors or bad cases. This PR will allow many responses to be added to a path like this:

```php
#[
    GET("/path", ["Dummy"], "Dummy path"),
    Response(200),
    Response(401),
]
public function get(): void
```