### PR TITLE
Allow extra uncommon settings be added to properties

### DIFF
--- a/src/Attributes/Property.php
+++ b/src/Attributes/Property.php
@@ -27,6 +27,7 @@ class Property implements PropertyInterface, JsonSerializable
         private ?array $enum = null,
         private ?string $ref = null,
         private bool $isObjectId = false,
+        private array $extra = [],
     ) {
         if ($this->ref) {
             $ref = explode('\\', $this->ref);
@@ -99,6 +100,10 @@ class Property implements PropertyInterface, JsonSerializable
 
         if ($minimum) {
             $array['minimum'] = $minimum;
+        }
+
+        if ($this->extra) {
+            $array = array_merge($array, $this->extra);
         }
 
         return $array;

--- a/src/Attributes/PropertyItems.php
+++ b/src/Attributes/PropertyItems.php
@@ -19,6 +19,7 @@ class PropertyItems implements PropertyInterface, JsonSerializable
         private string $type,
         private ?string $ref = null,
         private mixed $example = '',
+        private array $extra = [],
     ) {
         if ($this->ref) {
             $ref = explode('\\', $this->ref);
@@ -59,6 +60,10 @@ class PropertyItems implements PropertyInterface, JsonSerializable
                 'type' => $this->type,
                 'example' => $this->example
             ];
+        }
+
+        if ($this->extra) {
+            $array = array_merge($array, $this->extra);
         }
 
         return $array;

--- a/src/Attributes/Response.php
+++ b/src/Attributes/Response.php
@@ -26,7 +26,8 @@ class Response implements JsonSerializable
         private string $description = '',
         private ?string $responseType = null,
         private ?string $schemaType = SchemaType::OBJECT,
-        private ?string $ref = null
+        private ?string $ref = null,
+        private array $extra = [],
     ) {
         if ($ref) {
             $this->schema = new Schema($schemaType);
@@ -59,6 +60,10 @@ class Response implements JsonSerializable
 
         if ($this->schema) {
             $array[$this->code]['content'] = $this->schema;
+        }
+
+        if ($this->extra) {
+            $array[$this->code] = array_merge($array[$this->code], $this->extra);
         }
 
         return $array;


### PR DESCRIPTION
... exemple the additionalProperties settings for dictionaries.

https://swagger.io/docs/specification/data-models/dictionaries/

One of the exported properties in one of my project have the type:
 `array<int, array<string, int>>`  aka a list of dictionaries of integers,

By using:
```php
#[
    Schema,
    // ...
    Property(Type::ARRAY, 'distances'),
    PropertyItems(Type::OBJECT, extra: ['additionalProperties' => ['type' => PropertyType::INT]]),
]
```

I get
```json
"distances": {
    "items": {
        "type": "object",
        "example": null
    },
    "additionalProperties": {
        "type": "integer"
    }
},
```
