### PR TITLE
UnhandledMatchError is thrown if Class has additional non OA attributes

### DIFF
--- a/src/GeneratorSchemas.php
+++ b/src/GeneratorSchemas.php
@@ -22,11 +22,19 @@ class GeneratorSchemas
             $instance = $attribute->newInstance();
             $className = $reflectionClass->getName();
 
-            match ($name) {
-                Schema::class => $builder->addSchema($instance, $className),
-                Property::class => $builder->addProperty($instance),
-                PropertyItems::class => $builder->addPropertyItems($instance),
-            };
+            switch ($name) {
+                case Schema::class:
+                    $builder->addSchema($instance, $className);
+                    break;
+                case Property::class:
+                    $builder->addProperty($instance);
+                    break;
+                case PropertyItems::class:
+                    $builder->addPropertyItems($instance);
+                    break;
+                default:
+                    break;
+            }
         }
 
         $this->components[] = $builder->getComponent();


### PR DESCRIPTION
If a class with schema has additional attributes: e.g. Doctrine ORM:

```
#[ORM\Entity(repositoryClass: MyEntityRepository::class)]
#[Schema]
class MyEntity {
}
```

This will throw a `UnhandledMatchError`. To allow additional non OA attributes to parse through the generator, I have changed `match` to `switch` statement to allow default break if class name is not matched.