### PR TITLE
Property enum can now accept a class string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "symfony/finder": "^6.0",
         "symfony/http-foundation": "^6.0",
         "symfony/string": "^6.2"

--- a/src/Attributes/Property.php
+++ b/src/Attributes/Property.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenApiGenerator\Attributes;
 
 use Attribute;
+use BackedEnum;
 use OpenApiGenerator\Types\PropertyType;
 use JsonSerializable;
 
@@ -24,7 +25,7 @@ class Property implements PropertyInterface, JsonSerializable
         private string $description = '',
         private mixed $example = null,
         private ?string $format = null,
-        private ?array $enum = null,
+        private null|array|string $enum = null,
         private ?string $ref = null,
         private bool $isObjectId = false,
         private array $extra = [],
@@ -91,7 +92,7 @@ class Property implements PropertyInterface, JsonSerializable
         }
 
         if ($this->enum) {
-            $array['enum'] = $this->enum;
+            $array['enum'] = $this->enum();
         }
 
         if ($this->example) {
@@ -107,5 +108,21 @@ class Property implements PropertyInterface, JsonSerializable
         }
 
         return $array;
+    }
+
+    private function enum(): ?array
+    {
+        if (!is_string($this->enum)) {
+            return $this->enum;
+        }
+
+        if(!enum_exists($this->enum)) {
+            return null;
+        }
+
+        return array_map(
+            static fn(BackedEnum $enum) => $enum->value,
+            $this->enum::cases()
+        );
     }
 }


### PR DESCRIPTION
This is the corresponding PR to #31. It bumps the required PHP version to 8.1 and checks for an enum class string in `OpenApiGenerator\Attributes\Property`. Only `BackedEnum` are allowed, so a type error will be thrown for pure enums.